### PR TITLE
Bugfix: use correct background histogram per species

### DIFF
--- a/include/generators/BackgroundGenerator.hh
+++ b/include/generators/BackgroundGenerator.hh
@@ -34,8 +34,11 @@ class BackgroundGenerator : public GeneratorBase
     G4String fBkgFilename;
     G4double fBkgTimeWindow;
     TFile* fBkgFile;
-    TH3D *fhxyE;
-    TH3D *fhdir;
+    
+    std::map<std::string, TH3D*> fhxyElist;
+    std::map<std::string, TH3D*> fhdirlist;
+    TH3D* fhxyE;
+    TH3D* fhdir;
 
     std::vector<std::string> fSpeciesList = { "mu_plus","mu_minus","neut" };
     G4double LHC_orbitPeriod_s = 88.924e-6; // orbit is 88.924 us

--- a/src/generators/BackgroundGenerator.cc
+++ b/src/generators/BackgroundGenerator.cc
@@ -57,10 +57,10 @@ void BackgroundGenerator::LoadData()
     // get the input histograms
     // 3D histo in (x, y, E): normalized, to be used for the main extraction
     // 3D histo in (xdircos, ydircos, E): one energy is extracted, 
-    fhxyE = (TH3D*)fBkgFile->Get(hxyE_path.c_str());
-    fhdir = (TH3D*)fBkgFile->Get(hdir_path.c_str());
+    fhxyElist[name] = (TH3D*)fBkgFile->Get(hxyE_path.c_str());
+    fhdirlist[name] = (TH3D*)fBkgFile->Get(hdir_path.c_str());
 
-    if(!fhxyE || !fhdir) {
+    if(!fhxyElist[name] || !fhdirlist[name]) {
       G4String err = "Histograms " + hxyE_path + " or " + hdir_path + " unavailable in " + fBkgFilename;
       G4Exception("BackgroundGenerator", "FileError", FatalErrorInArgument, err.c_str());
     }
@@ -143,6 +143,10 @@ void BackgroundGenerator::GeneratePrimaries(G4Event* anEvent)
 
   // for each background species available...
   for(auto const name : fSpeciesList) {
+    
+    // select the right histograms
+    fhxyE = fhxyElist[name];
+    fhdir = fhdirlist[name];
     
     // get total number of particles to shoot
     // TODO: currently launching the equivalent of the requested time window


### PR DESCRIPTION
This PR includes a quick bugfix for the `BackgroundGenerator.cc` class (introduced by me! 🙃 ).

Although the histograms for each species were correctly loaded in `LoadData()`, they were all stored in the same pointers (`fhxyE`, `fhdir`), resulting in only the last-loaded histograms being used for all species during particle generation.

The fix introduces intermediate maps (`fhxyElist` and `fhdirlist`) to store the histograms for each species. During particle generation, the appropriate histogram pointers are retrieved from these maps based on the current species, ensuring that each species uses its corresponding background data.