### PR TITLE
Clean-up GDML volume names

### DIFF
--- a/src/DetectorConstruction.cc
+++ b/src/DetectorConstruction.cc
@@ -244,7 +244,7 @@ G4VPhysicalVolume* DetectorConstruction::Construct()
   if (m_saveGdml) {
     G4GDMLParser fParser;
     G4cout << "Exporting geometry to " << m_fileGdml << G4endl;
-    fParser.Write(m_fileGdml, worldPV);
+    fParser.Write(m_fileGdml, worldPV, false);
   }
 
   return worldPV;


### PR DESCRIPTION
This PR includes a small change in the setting of the `GDMLParser::Write()` call to clean-up the volume names in the GDML files by setting `storeReferences=false`. This is needed for [FPFDisplay](https://github.com/FPFSoftware/FPFDisplay) and possibly every other use of the GDML files (e.g: ACTS?).

From the GDML documention of `GDMLParser::Write()`:

> There exists also an optional third parameter, which is a Boolean value set by default to
TRUE. This parameter tells how you would like the names of volumes (as well as of
solids, materials and all entities) to be formatted in your output GDML file:
>
>true (default) – The names will be concatenated with their logical address in
hexadecimal format. This is to avoid name duplication in the GDML output; in fact
Geant4 allows different volumes (as well as materials and solids) with the same name.
When you will read the GDML output file back into Geant4 the address part will be
stripped off and you will have the original names. This is almost always safe.
>
>false – The names will NOT be concatenated with anything. So the names in the output
file will correspond exactly to the ones you have in Geant4. This is the prettiest format
although you have to be REALLY sure that you don’t have name duplication inside
Geant4, otherwise this will generate a GDML output with duplicated names, which will be
unreadable by any parser of course.