### PR TITLE
Fix volume overlap in GDML

### DIFF
--- a/src/geometry/FASER2DetectorConstruction.cc
+++ b/src/geometry/FASER2DetectorConstruction.cc
@@ -174,7 +174,7 @@ FASER2DetectorConstruction::FASER2DetectorConstruction()
   //TODO: Calorimeter volumes are just dummy placeholder boxes - detailed simulation studies required!
   auto ECalBox = new G4Box("ECalBox", fMagnetWindowX/2.+fMagnetYokeThicknessX, fMagnetWindowY/2.+fMagnetYokeThicknessY, fEMCaloThickness/2.);
   auto HCalBox = new G4Box("HCalBox", fMagnetWindowX/2.+fMagnetYokeThicknessX, fMagnetWindowY/2.+fMagnetYokeThicknessY, fHadCaloThickness/2.);
-  auto IronWallBox = new G4Box("HCalBox", fMagnetWindowX/2.+fMagnetYokeThicknessX, fMagnetWindowY/2.+fMagnetYokeThicknessY, fIronWallThickness/2.);
+  auto IronWallBox = new G4Box("IronWallBox", fMagnetWindowX/2.+fMagnetYokeThicknessX, fMagnetWindowY/2.+fMagnetYokeThicknessY, fIronWallThickness/2.);
 
   fEMCalLogical = new G4LogicalVolume(ECalBox, (fillCaloAndWallVolumes) ? fMaterials->Material("Copper"): fMaterials->Material("Air"), "FASER2ECAlLogical");
   fHadCalLogical = new G4LogicalVolume(HCalBox, (fillCaloAndWallVolumes) ? fMaterials->Material("Iron"): fMaterials->Material("Air"), "FASER2HCAlLogical");


### PR DESCRIPTION
This PR fixes an overlap in the GDML geometry spotted with `FPFDisplay`.

![Screenshot 2025-06-02 at 11 30 05](https://github.com/user-attachments/assets/e6585e2f-3b74-45ca-8a04-1e59d167490e)

The FASER2 iron wall volume was incorrectly referencing the hadron calorimeter solid due to a copy-paste error in the solid name. While this didn't cause any issues in Geant4 itself, it caused volume overlaps with the GDML format. Basically both `FASER2HCAlLogical`and `FASER2IronWallLogical` were using the solid name `HCalBox` with the larger thickness.

```
  <box lunit="mm" name="ECalBox" x="6000" y="3000" z="1000"/>
  <box lunit="mm" name="HCalBox" x="6000" y="3000" z="2000"/>
  <box lunit="mm" name="HCalBox" x="6000" y="3000" z="3000"/>
...
    <volume name="FASER2ECAlLogical">
      <materialref ref="Copper"/>
      <solidref ref="ECalBox"/>
    </volume>
    <volume name="FASER2HCAlLogical">
      <materialref ref="Iron"/>
      <solidref ref="HCalBox"/>
    </volume>
    <volume name="FASER2IronWallLogical">
      <materialref ref="Iron"/>
      <solidref ref="HCalBox"/>
    </volume>
```