### PR TITLE
Fix memory leak in PixelMap3D

### DIFF
--- a/src/PixelMap3D.cc
+++ b/src/PixelMap3D.cc
@@ -26,7 +26,7 @@ PixelMap3D::~PixelMap3D()
   fBinX.clear();
   fBinY.clear();
   fBinZ.clear();
-  for (G4int iPrim= 0; iPrim< fNPrim; ++iPrim) {
+  for (G4int iPrim= 0; iPrim< fNPrim+1; ++iPrim) {
     delete hitClusterZX[iPrim];
     delete hitClusterZY[iPrim];
     delete vtxHitClusterZX[iPrim];
@@ -292,6 +292,8 @@ void PixelMap3D::Process3DPM(File &h5file, FPFNeutrino nu, G4bool save3D)
     }
     if (save3D) pm_data.insert(fEvtID, i, x[3], x[0], x[1], x[2]);
   }
+  delete[] x;
+  delete[] bins;
 }
 
 void PixelMap3D::Write2DPMToFile(TFile* thefile)


### PR DESCRIPTION
Fix for issue #10

Changes:
- Added a call to `delete[]` for arrays which are dynamically allocated
- Modified `for` loop in destructor so that all histogram vector elements are properly freed

Additionally, in testing I noticed a considerable speed up in the code when removing the invocations of `PixelMap3d` in analysis manager. This object isn't required when running the simulation without FLArE, I will probably implement that change in PR #8 as part of the output file overhaul.

Memory usage when running `dark_photon_hepmc.mac` with 1000 events before fix:
![image](https://github.com/user-attachments/assets/3a3efbd9-4f4c-4100-8327-6e30928343ea)

Memory usage when running `dark_photon_hepmc.mac` with 1000 events after fix:
![image](https://github.com/user-attachments/assets/a0b7b485-3bd6-4940-85c1-5b737dfe6bb4)

